### PR TITLE
fix: correct the variable syntax

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,4 +25,4 @@ jobs:
         env:
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
         run: |
-          render deployments create --service-id ${{ vars.RENDER_SERVICE_ID }} --wait
+          render deployments create --service-id ${{ secrets.RENDER_SERVICE_ID }} --wait


### PR DESCRIPTION
bad syntax in RENDER_SERVICE_ID repository var